### PR TITLE
Update index.md

### DIFF
--- a/source/blazor-university-com/input/pages/components/component-events/index.md
+++ b/source/blazor-university-com/input/pages/components/component-events/index.md
@@ -15,9 +15,10 @@ consuming components can specify in Razor mark-up which method to call when the 
 ## Adding an event to the Counter component
 
 In a new Blazor app, edit the **/Pages/Counter.razor** file and add a new callback parameter.
-
+```razor
 [Parameter]
 public EventCallback<int> OnMultipleOfThree { get; set; }
+```
 
 This declares a new `EventCallback` named OnMultipleOfThree that any consuming component can register an interest in.
 The `<int>` specifies that the value emitted by the event callback will be a `System.Int32`.


### PR DESCRIPTION
The '<int>' in 'public EventCallback<int>' does not display when it's not enclosed in blazor code tags.

It appears just as 'public EventCallback'