### PR TITLE
fix typo

### DIFF
--- a/source/blazor-university-com/input/pages/overview/blazor-hosting-models/index.md
+++ b/source/blazor-university-com/input/pages/overview/blazor-hosting-models/index.md
@@ -77,7 +77,7 @@ to send that event to the server and execute the relevant .NET code.
 {
   private int CurrentCount;
 
-  public void Increment()
+  public void IncrementCount()
   {
     CurrentCount++;
   }


### PR DESCRIPTION
event call and function name need to match