### PR TITLE
Update comment to mention correct directive

### DIFF
--- a/source/blazor-university-com/input/pages/components/literals-expressions-and-directives/directives/index.md
+++ b/source/blazor-university-com/input/pages/components/literals-expressions-and-directives/directives/index.md
@@ -24,7 +24,7 @@ An exception to this is when we wish to pass a lambda; lambdas must be escaped w
 The following code shows how the `@onclick` directive is used to add the DOM onclick event to a rendered H1 element.
 
 ```razor
-// Razor mark-up with @ref directive
+// Razor mark-up with @onclick directive
 <h1 @onclick=H1Clicked>Hello, world!</h1>
 
 @code

--- a/source/blazor-university-com/input/pages/components/two-way-binding/binding-directives/index.md
+++ b/source/blazor-university-com/input/pages/components/two-way-binding/binding-directives/index.md
@@ -165,8 +165,8 @@ And something similar to the following (again abridged) code for converting user
 
 The code hooks into the HTML `onchange` event and then, via the binder, sets our member value when the event is triggered.
 
-The different when setting the `@bind-value:format` directive attribute value is that the format we
-provide passed in the generated code to both `BindConverter.Format` and `EventCallback.Factory.CreateBinder`.
+The difference when setting the `@bind-value:format` directive attribute value is that the format we
+provide is passed in the generated code to both `BindConverter.Format` and `EventCallback.Factory.CreateBinder`.
 
 ```cs
 ...BindConverter.FormatValue(Name, format: "yyyy-MM-dd");


### PR DESCRIPTION
A comment in a code snippet mentioned the use of the ref directive, when the snippet showed the use of the onclick directive