### PR TITLE
Add missing code fencing

### DIFF
--- a/source/blazor-university-com/input/pages/forms/index.md
+++ b/source/blazor-university-com/input/pages/forms/index.md
@@ -18,12 +18,15 @@ The key feature to the `EditForm` is its `Model` parameter. This parameter provi
 
 Let's start by creating a class we can use with our `EditForm`. At this point a simple empty class will suffice.
 
+```cs
 public class Person
 {
 }
+```
 
 Edit the standard **index.razor** page as follows:
 
+```razor {: .line-numbers}
 @page "/"
 
 <EditForm Model=@Person>
@@ -34,17 +37,21 @@ Edit the standard **index.razor** page as follows:
 {
 	Person Person = new Person();
 }
+```
 
 Line 9 creates an instance of a `Person` for our form to bind to. Line 3 creates an `EditForm` and sets its `Model` parameter to our instance. The preceding razor mark-up results in the following HTML.
 
+```html
 <form>
 	<input class="btn btn-primary" type="submit" value="Submit">
 </form>
+```
 
 ## Detecting form submission
 
 When the user clicks the **Submit** button in the preceding example, the `EditForm` will trigger its `OnSubmit` event. We can use this event in our code to handle any business logic.
 
+```razor
 @page "/"
 
 <h1>Status: @Status</h1>
@@ -63,6 +70,7 @@ When the user clicks the **Submit** button in the preceding example, the `EditFo
 		// Post data to the server, etc
 	}
 }
+```
 
 Form submission will be covered in more depth in the [Handling form submission](/forms/handling-form-submission/) section.
 


### PR DESCRIPTION
The razor and html code is not code-fenced and renders as HTML effectively hiding from the website or rendered markdown reader.

The code is there so adequate code fencing should resolve that.