### PR TITLE
fix missing code fence close

### DIFF
--- a/source/blazor-university-com/input/pages/templating-components-with-renderfragements/using-typeparam-to-create-generic-components/index.md
+++ b/source/blazor-university-com/input/pages/templating-components-with-renderfragements/using-typeparam-to-create-generic-components/index.md
@@ -29,11 +29,13 @@ We'll also add a `[Parameter]` property, expecting an `IEnumerable<TItem>`.
   [Parameter]
   public IEnumerable<TItem> Data { get; set; }
 }
+```
 
 ## Using the generic component
 
 Create a `Person` class with three properties.
 
+```cs
 public class Person
 {
   public string Salutation { get; set; }


### PR DESCRIPTION
On the `@typeparam` page of RenderFragments, a code fence isn't closed properly and then encompasses some Markdown as well as the next code block before it is closed.