### PR TITLE
Fix input value in literals expressions example

### DIFF
--- a/source/blazor-university-com/input/pages/components/literals-expressions-and-directives/index.md
+++ b/source/blazor-university-com/input/pages/components/literals-expressions-and-directives/index.md
@@ -177,7 +177,7 @@ by enclosing the expression text in brackets.
       <td>
         &lt;input value=<code>@($"Size is {DoubleInputSize()}")</code> /&gt;
       </td>
-      <td>&lt;input size="Size is 16"/&gt;</td>
+      <td>&lt;input value="Size is 16"/&gt;</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Replaced "size" with "value".

<img width="1004" height="194" alt="grafik" src="https://github.com/user-attachments/assets/199768e1-271e-483f-87c2-13df188a1c2a" />
